### PR TITLE
境界が範囲外に出たときにエラーで落ちる

### DIFF
--- a/scr/OCR_by_google.py
+++ b/scr/OCR_by_google.py
@@ -135,7 +135,7 @@ class OCR(IOCR):
                             w: int = ver[1].x - x
                             h: int = ver[3].y - y
                             text = symbol.text
-                            p: tuple[int, int] = (x, y)
+                            p: tuple[int, int] = (max(0, x), max(0, y))
                             rect = Rect((p, w, h))
                             box = Box(text, rect)
                             boxes.append(box)


### PR DESCRIPTION
https://github.com/Shena4746/ocr-japanese-doc-by-line/blob/d28cfb0ee2644a54a6451854fb2f564d863d8ecb/scr/OCR_by_google.py#L138

ここでxかyが負になり

https://github.com/Shena4746/ocr-japanese-doc-by-line/blob/d28cfb0ee2644a54a6451854fb2f564d863d8ecb/scr/Rect.py#L83-L84

で引っかかります。